### PR TITLE
ver 0.9.12

### DIFF
--- a/SynicSugar/Assets/SynicSugar/Runtime/Core/EOS/UserIdFormatter.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/Core/EOS/UserIdFormatter.cs
@@ -3,6 +3,11 @@ using MemoryPack;
 namespace SynicSugar {
     internal class UserIdFormatter : MemoryPackFormatter<UserId>
     {
+        /// <summary>
+        /// Serialize UserId as string.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
         public override void Serialize(ref MemoryPackWriter writer, ref UserId value)
         {
             if (value == null || !value.IsValid()){
@@ -13,6 +18,12 @@ namespace SynicSugar {
             writer.WriteString(value.ToString());
         }
 
+        /// <summary>
+        /// Deserialize UserId from cache by string. <br />
+        /// If the corresponding value is not in cache, null is returned, so it must be generated and registered to UserIds in advance.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="value"></param>
         public override void Deserialize(ref MemoryPackReader reader, ref UserId value)
         {
             if (reader.PeekIsNull())

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
@@ -20,7 +20,6 @@ namespace SynicSugar.MatchMake {
         /// <returns>Return true, after end the conenction. If pass time before finish prepartion, return false/</returns>
         internal async UniTask<Result> WaitConnectPreparation(CancellationToken token, int timeoutMS){
             await UniTask.WhenAny(UniTask.WaitUntil(() => p2pInfo.Instance.ConnectionNotifier.completeConnectPreparetion, cancellationToken: token), UniTask.Delay(timeoutMS, cancellationToken: token));
-            
             Logger.Log("WaitConnectPreparation", p2pInfo.Instance.ConnectionNotifier.completeConnectPreparetion ? "Connection setup is ready. Proceed to user list synchronization." : "Connection setup is not ready. Timeout.");
 
             if(!p2pConfig.Instance.UseDisconnectedEarlyNotify){
@@ -103,9 +102,10 @@ namespace SynicSugar.MatchMake {
                 RemoteUserId = targetId.AsEpic,
                 SocketId = p2pConfig.Instance.sessionCore.SocketId,
                 Channel = BASICINFO_CH,
+                Data = payload,
                 AllowDelayedDelivery = true,
                 Reliability = PacketReliability.ReliableUnordered,
-                Data = payload
+                DisableAutoAcceptConnection = true
             };
 
             ResultE result = p2pInterface.SendPacket(ref options);

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
@@ -60,7 +60,7 @@ namespace SynicSugar.MatchMake {
             MemoryPackSerializer.Serialize(compressor, basicInfo);
 
             ArraySegment<byte> payload = new ArraySegment<byte>(compressor.ToArray());
-
+ 
         #if SYNICSUGAR_PACKETINFO
             UnityEngine.Debug.Log($"SendUserList: ch {BASICINFO_CH} / payload {payload.ToHexString()}");
         #endif
@@ -127,12 +127,10 @@ namespace SynicSugar.MatchMake {
             ArraySegment<byte> payload = new();
             uint nextPacketSizeBytes = 0;
 
-            UnityEngine.Debug.Log($"size option(ch): {getNextReceivedPacketSizeOptions.RequestedChannel}");
             while(!token.IsCancellationRequested){
                 bool recivePacket = GetPacketFromBuffer(ref getNextReceivedPacketSizeOptions, ref nextPacketSizeBytes ,ref ch, ref payload);
 
                 if(recivePacket){
-                    UnityEngine.Debug.Log("ReciveUserIdsPacket");
                     ConvertFromPacket(in ch, in payload);
                     return;
                 }

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
@@ -33,12 +33,11 @@ namespace SynicSugar.MatchMake {
         /// Different Assembly can have same CH, but not sorted when receive packet. <br />
         /// So must not use the same ch for what SynicSugar may receive at the same time.
         /// </summary>
-        const byte basicInfoCh = 252;
-        const int SendBatchSize = 8;
-        byte ch;
-        ProductUserId id;
-        ArraySegment<byte> payload;
+        const byte BASICINFO_CH = 252;
+        const int SEND_BATCH_SIZE = 8;
         SocketId ReferenceSocketId;
+        // Allocate memory at maximum packet size in advance.
+        byte[] buffer = new byte[1170];
         #region Send
         /// <summary>
         /// For Host to send List after re-connecter has came.
@@ -56,7 +55,7 @@ namespace SynicSugar.MatchMake {
 
             using var compressor  = new BrotliCompressor(MatchMakeManager.Instance.BasicInfoPacketCompressionLevel);
             MemoryPackSerializer.Serialize(compressor, basicInfo);
-            SendPacket(basicInfoCh, compressor.ToArray(), target);
+            SendPacket(BASICINFO_CH, compressor.ToArray(), target);
         }
         /// <summary>
         /// For Host to send AllUserList after connection.
@@ -68,10 +67,10 @@ namespace SynicSugar.MatchMake {
             using var compressor  = new BrotliCompressor(MatchMakeManager.Instance.BasicInfoPacketCompressionLevel);
             MemoryPackSerializer.Serialize(compressor, basicInfo);
             
-            int count = SendBatchSize;
+            int count = SEND_BATCH_SIZE;
             var compressorArray = compressor.ToArray();
             foreach(var id in p2pInfo.Instance.userIds.RemoteUserIds){
-                SendPacket(basicInfoCh, compressorArray, id);
+                SendPacket(BASICINFO_CH, compressorArray, id);
 
                 count--;
                 if(count <= 0){
@@ -80,7 +79,7 @@ namespace SynicSugar.MatchMake {
                         Logger.LogWarning("SendUserListToAll", "Get out of the loop by Cancel");
                         break;
                     }
-                    count = SendBatchSize;
+                    count = SEND_BATCH_SIZE;
                 }
             }
         }
@@ -111,20 +110,24 @@ namespace SynicSugar.MatchMake {
             //Next packet size
             var getNextReceivedPacketSizeOptions = new GetNextReceivedPacketSizeOptions {
                 LocalUserId = p2pInfo.Instance.userIds.LocalUserId.AsEpic,
-                RequestedChannel = basicInfoCh
+                RequestedChannel = BASICINFO_CH
             };
+            byte ch = BASICINFO_CH;
+            ProductUserId id = new();
+            ArraySegment<byte> payload = new();
             while(!token.IsCancellationRequested){
                 bool recivePacket = GetPacketFromBuffer(ref p2pInterface, ref getNextReceivedPacketSizeOptions, ref ch, ref id, ref payload);
 
                 if(recivePacket){
-                    ConvertFromPacket();
+                    UnityEngine.Debug.Log("ReciveUserIdsPacket");
+                    ConvertFromPacket(in ch, in payload);
                     return;
                 }
                 await UniTask.Yield(cancellationToken: token);
             }
         }
         /// <summary>
-        /// To get RECONNECTIONCH packet.
+        /// To get basicInfo packet about a user list.
         /// </summary>
         /// <param name="ch"></param>
         /// <param name="id"></param>
@@ -132,7 +135,6 @@ namespace SynicSugar.MatchMake {
         /// <returns></returns>
         bool GetPacketFromBuffer(ref P2PInterface p2pInterface,ref GetNextReceivedPacketSizeOptions sizeOptions, ref byte ch, ref ProductUserId id, ref ArraySegment<byte> payload){
             ResultE result = p2pInterface.GetNextReceivedPacketSize(ref sizeOptions, out uint nextPacketSizeBytes);
-
             if(result != ResultE.Success){
                 return false; //No packet
             }
@@ -141,24 +143,23 @@ namespace SynicSugar.MatchMake {
             ReceivePacketOptions options = new ReceivePacketOptions(){
                 LocalUserId = p2pInfo.Instance.userIds.LocalUserId.AsEpic,
                 MaxDataSizeBytes = nextPacketSizeBytes,
-                RequestedChannel = basicInfoCh
+                RequestedChannel = BASICINFO_CH
             };
 
-            byte[] data = new byte[nextPacketSizeBytes];
-            var dataSegment = new ArraySegment<byte>(data);
-            result = p2pInterface.ReceivePacket(ref options, ref id, ref ReferenceSocketId, out byte outChannel, dataSegment, out uint bytesWritten);
+            payload = new ArraySegment<byte>(buffer, 0, (int)nextPacketSizeBytes);
+            result = p2pInterface.ReceivePacket(ref options, ref id, ref ReferenceSocketId, out byte outChannel, payload, out uint bytesWritten);
             
             if (result != ResultE.Success){
                 return false; //No packet
             }
             ch = outChannel;
-            payload = new ArraySegment<byte>(dataSegment.Array, dataSegment.Offset, (int)bytesWritten);;
 
             return true;
         }
         
-        void ConvertFromPacket(){
-            if(ch != basicInfoCh){
+        void ConvertFromPacket(in byte ch, in ArraySegment<byte> payload){
+            if(ch != BASICINFO_CH){
+                Logger.LogError("ConvertFromPacket", "Could not get packets about UserList because the packets were on different channels.");
                 return;
             }
 

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
@@ -167,7 +167,7 @@ namespace SynicSugar.MatchMake {
             var decompressed = decompressor.Decompress(payload);
 
             BasicInfo data = MemoryPackSerializer.Deserialize<BasicInfo>(decompressed);
-            p2pInfo.Instance.userIds.OverwriteAllUserIdsWithOrdered(data);
+            p2pInfo.Instance.userIds.OverwriteUserIdsWithHostData(data);
         }
         #endregion
     }

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
@@ -8,7 +8,6 @@ using PlayEveryWare.EpicOnlineServices;
 using Epic.OnlineServices;
 using Epic.OnlineServices.P2P;
 using ResultE = Epic.OnlineServices.Result;
-using UnityEngine;
 
 namespace SynicSugar.MatchMake {
     internal class ConnectionSetupHandler {
@@ -16,7 +15,7 @@ namespace SynicSugar.MatchMake {
         /// To open and request initial connection.
         /// </summary>
         /// <returns>Return true, after end the conenction. If pass time before finish prepartion, return false/</returns>
-        internal static async UniTask<Result> WaitConnectPreparation(CancellationToken token, int timeoutMS){
+        internal async UniTask<Result> WaitConnectPreparation(CancellationToken token, int timeoutMS){
             await UniTask.WhenAny(UniTask.WaitUntil(() => p2pInfo.Instance.ConnectionNotifier.completeConnectPreparetion, cancellationToken: token), UniTask.Delay(timeoutMS, cancellationToken: token));
 
             Logger.Log("WaitConnectPreparation", "Connection setup is ready. Proceed to user list synchronization.");
@@ -44,7 +43,7 @@ namespace SynicSugar.MatchMake {
         /// <summary>
         /// For Host to send List after re-connecter has came.
         /// </summary>
-        internal static void SendUserList(UserId target){
+        internal void SendUserList(UserId target){
             BasicInfo basicInfo = new BasicInfo();
             basicInfo.userIds = p2pInfo.Instance.AllUserIds.ConvertAll(id => id.ToString());
             
@@ -62,7 +61,7 @@ namespace SynicSugar.MatchMake {
         /// <summary>
         /// For Host to send AllUserList after connection.
         /// </summary>
-        internal static async UniTask SendUserListToAll(CancellationToken token){
+        internal async UniTask SendUserListToAll(CancellationToken token){
             BasicInfo basicInfo = new BasicInfo();
             basicInfo.userIds = p2pInfo.Instance.AllUserIds.ConvertAll(id => id.ToString());
             

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/ConnectionSetupHandler.cs
@@ -20,8 +20,8 @@ namespace SynicSugar.MatchMake {
         /// <returns>Return true, after end the conenction. If pass time before finish prepartion, return false/</returns>
         internal async UniTask<Result> WaitConnectPreparation(CancellationToken token, int timeoutMS){
             await UniTask.WhenAny(UniTask.WaitUntil(() => p2pInfo.Instance.ConnectionNotifier.completeConnectPreparetion, cancellationToken: token), UniTask.Delay(timeoutMS, cancellationToken: token));
-
-            Logger.Log("WaitConnectPreparation", "Connection setup is ready. Proceed to user list synchronization.");
+            
+            Logger.Log("WaitConnectPreparation", p2pInfo.Instance.ConnectionNotifier.completeConnectPreparetion ? "Connection setup is ready. Proceed to user list synchronization." : "Connection setup is not ready. Timeout.");
 
             if(!p2pConfig.Instance.UseDisconnectedEarlyNotify){
                 ((EOSSessionManager)p2pConfig.Instance.sessionCore).RemoveNotifyPeerConnectionnEstablished();

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Core/BasicInfo.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Core/BasicInfo.cs
@@ -7,6 +7,10 @@ namespace SynicSugar.P2P {
     /// </summary>
     [MemoryPackable]
     public partial class BasicInfo {
+        /// <summary>
+        /// UserId uses UserIdFormatter that need to register id to　cache before use. <br />
+        /// So, use string instead of UserId.
+        /// </summary>
         public List<string> userIds = new List<string>();
         public List<byte> disconnectedUserIndexes = new List<byte>();
         public uint ElapsedSecSinceStart = 0;

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Core/Lobby.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Core/Lobby.cs
@@ -166,14 +166,14 @@ namespace SynicSugar.MatchMake {
                 return;
             }
 
-            InitFromLobbyDetails(outLobbyDetailsHandle);
+            UpdateLobbyWithLatestLobbyDetails(outLobbyDetailsHandle);
             outLobbyDetailsHandle.Release();
         }
         /// <summary>
         /// Initializing the given LobbyDetails handle and caches all relevant attributes
         /// </summary>
         /// <param name="lobbyDetailsHandle">Specified LobbyDetails handle</param>
-        void InitFromLobbyDetails(LobbyDetails lobbyDetailsHandle){
+        void UpdateLobbyWithLatestLobbyDetails(LobbyDetails lobbyDetailsHandle){
             // Get owner
             var lobbyDetailsGetLobbyOwnerOptions = new LobbyDetailsGetLobbyOwnerOptions();
             ProductUserId newLobbyOwner = lobbyDetailsHandle.GetLobbyOwner(ref lobbyDetailsGetLobbyOwnerOptions);
@@ -185,11 +185,11 @@ namespace SynicSugar.MatchMake {
             var lobbyDetailsCopyInfoOptions = new LobbyDetailsCopyInfoOptions();
             ResultE infoResult = lobbyDetailsHandle.CopyInfo(ref lobbyDetailsCopyInfoOptions, out LobbyDetailsInfo? outLobbyDetailsInfo);
             if (infoResult != ResultE.Success){
-                Logger.LogError("InitFromLobbyDetails", "Can't copy lobby info.", (Result)infoResult);
+                Logger.LogError("UpdateLobbyWithLatestLobbyDetails", "Can't copy lobby info.", (Result)infoResult);
                 return;
             }
             if (outLobbyDetailsInfo == null){
-                Logger.LogError("InitFromLobbyDetails", "Could not copy info: outLobbyDetailsInfo is null.");
+                Logger.LogError("UpdateLobbyWithLatestLobbyDetails", "Could not copy info: outLobbyDetailsInfo is null.");
                 return;
             }
 
@@ -201,7 +201,7 @@ namespace SynicSugar.MatchMake {
             bDisableHostMigration = (bool)(outLobbyDetailsInfo?.AllowHostMigration);
             RejoinAfterKickRequiresInvite = (bool)(outLobbyDetailsInfo?.RejoinAfterKickRequiresInvite);
 
-            Logger.Log("InitFromLobbyDetails", $"Update Lobby Data. {System.Environment.NewLine} MaxLobbyMembers {MaxLobbyMembers} / PermissionLevel {PermissionLevel} / BucketId {BucketId} / AllowInvites {bAllowInvites} / RTCRoomEnabled {bEnableRTCRoom} / AllowHostMigration {bDisableHostMigration} / RejoinAfterKickRequiresInvite {RejoinAfterKickRequiresInvite}");
+            Logger.Log("UpdateLobbyWithLatestLobbyDetails", $"Update Lobby Data. {System.Environment.NewLine} MaxLobbyMembers {MaxLobbyMembers} / PermissionLevel {PermissionLevel} / BucketId {BucketId} / AllowInvites {bAllowInvites} / RTCRoomEnabled {bEnableRTCRoom} / AllowHostMigration {bDisableHostMigration} / RejoinAfterKickRequiresInvite {RejoinAfterKickRequiresInvite}");
 
             // Get attributes
             Attributes.Clear();
@@ -233,7 +233,7 @@ namespace SynicSugar.MatchMake {
                     ResultE memberAttributeResult = lobbyDetailsHandle.CopyMemberAttributeByIndex(ref lobbyDetailsCopyMemberAttributeByIndexOptions, out Attribute? outAttribute);
 
                     if (memberAttributeResult != ResultE.Success){
-                        Logger.Log("InitFromLobbyDetails", "Can't copy member attribute.", (Result)memberAttributeResult);
+                        Logger.Log("UpdateLobbyWithLatestLobbyDetails", "Can't copy member attribute.", (Result)memberAttributeResult);
                         continue;
                     }
  

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -857,13 +857,13 @@ namespace SynicSugar.MatchMake {
                 p2pInfo.Instance.ConnectionNotifier.Disconnected(UserId.GetUserId(info.TargetUserId), Reason.Disconnected);
             }else if(info.CurrentStatus == LobbyMemberStatus.Joined){
                 p2pInfo.Instance.userIds.MoveTargetUserIdToRemoteUsersFromLeft(info.TargetUserId);
-                p2pInfo.Instance.ConnectionNotifier.Connected(UserId.GetUserId(info.TargetUserId));
                 // Send Id list.
                 if(p2pInfo.Instance.IsHost()){
                     ConnectionSetupHandler setupHandler = new();
                     setupHandler.SendUserList(UserId.GetUserId(info.TargetUserId));
                     Logger.Log($"MemberStatusNotyfy", $"Send user list to {UserId.GetUserId(info.TargetUserId).ToMaskedString()}.");
                 }
+                p2pInfo.Instance.ConnectionNotifier.Connected(UserId.GetUserId(info.TargetUserId));
             }
         }
         /// <summary>

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -857,12 +857,6 @@ namespace SynicSugar.MatchMake {
                 p2pInfo.Instance.ConnectionNotifier.Disconnected(UserId.GetUserId(info.TargetUserId), Reason.Disconnected);
             }else if(info.CurrentStatus == LobbyMemberStatus.Joined){
                 p2pInfo.Instance.userIds.MoveUserIdToConnectedFromDisconnected(info.TargetUserId);
-                // Send Id list.
-                if(p2pInfo.Instance.IsHost()){
-                    ConnectionSetupHandler setupHandler = new();
-                    setupHandler.SendUserList(UserId.GetUserId(info.TargetUserId));
-                }
-                p2pInfo.Instance.ConnectionNotifier.Connected(UserId.GetUserId(info.TargetUserId));
             }
         }
         /// <summary>
@@ -1430,6 +1424,7 @@ namespace SynicSugar.MatchMake {
         /// <returns></returns>
         async UniTask<Result> OpenConnection(ushort setupTimeoutSec, CancellationToken token){
             if(p2pConfig.Instance.relayControl != RelayControl.AllowRelays){
+                Logger.Log("OpenConnection", "Set relay control to allow.");
                 p2pConfig.Instance.SetRelayControl(p2pConfig.Instance.relayControl);
             }
             await p2pConfig.Instance.natRelayManager.Init();

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -855,8 +855,10 @@ namespace SynicSugar.MatchMake {
                 Logger.Log($"MemberStatusNotyfy", $"{UserId.GetUserId(info.TargetUserId).ToMaskedString()} diconnect from lobby.");
                 p2pInfo.Instance.userIds.MoveUserIdToDisconnected(info.TargetUserId);
                 p2pInfo.Instance.ConnectionNotifier.Disconnected(UserId.GetUserId(info.TargetUserId), Reason.Disconnected);
+                p2pConfig.Instance.sessionCore.CloseConnection(UserId.GetUserId(info.TargetUserId));
             }else if(info.CurrentStatus == LobbyMemberStatus.Joined){
                 p2pInfo.Instance.userIds.MoveUserIdToConnectedFromDisconnected(info.TargetUserId);
+                p2pConfig.Instance.sessionCore.AcceptConnection(UserId.GetUserId(info.TargetUserId));
             }
         }
         /// <summary>
@@ -1429,7 +1431,7 @@ namespace SynicSugar.MatchMake {
             }
             await p2pConfig.Instance.natRelayManager.Init();
             RemoveNotifyLobbyMemberUpdateReceived();
-            p2pConfig.Instance.sessionCore.OpenConnection(true);
+            p2pConfig.Instance.sessionCore.OpenConnection();
             Logger.Log("OpenConnection", "Sending a connection request to other peers.");
             
             ConnectionSetupHandler setupHandler = new();

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -1402,7 +1402,7 @@ namespace SynicSugar.MatchMake {
 
                 userIds.AllUserIds.Add(targetId);
 
-                if(userIds.LocalUserId != targetId){
+                if(targetId != userIds.LocalUserId){
                     userIds.RemoteUserIds.Add(targetId);
                 }
             }

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -860,7 +860,8 @@ namespace SynicSugar.MatchMake {
                 p2pInfo.Instance.ConnectionNotifier.Connected(UserId.GetUserId(info.TargetUserId));
                 // Send Id list.
                 if(p2pInfo.Instance.IsHost()){
-                    ConnectionSetupHandler.SendUserList(UserId.GetUserId(info.TargetUserId));
+                    ConnectionSetupHandler setupHandler = new();
+                    setupHandler.SendUserList(UserId.GetUserId(info.TargetUserId));
                     Logger.Log($"MemberStatusNotyfy", $"Send user list to {UserId.GetUserId(info.TargetUserId).ToMaskedString()}.");
                 }
             }
@@ -1436,19 +1437,19 @@ namespace SynicSugar.MatchMake {
             RemoveNotifyLobbyMemberUpdateReceived();
             p2pConfig.Instance.sessionCore.OpenConnection(true);
             Logger.Log("OpenConnection", "Sending a connection request to other peers.");
-
-            Result canConnect = await ConnectionSetupHandler.WaitConnectPreparation(token, setupTimeoutSec * 1000); //Pass time as ms.
+            
+            ConnectionSetupHandler setupHandler = new();
+            Result canConnect = await setupHandler.WaitConnectPreparation(token, setupTimeoutSec * 1000); //Pass time as ms.
             if(canConnect != Result.Success){
                 return Result.ConnectEstablishFailed;
             }
             //Host sends AllUserIds list, Guest Receives AllUserIds.
             if(p2pInfo.Instance.IsHost()){
                 Logger.Log("OpenConnection", "Sending UserList to other peers as the Host.");
-                await ConnectionSetupHandler.SendUserListToAll(token);
+                await setupHandler.SendUserListToAll(token);
             }else{
                 Logger.Log("OpenConnection", "Waiting for UserList from the Host.");
-                ConnectionSetupHandler basicInfo = new();
-                await basicInfo.ReciveUserIdsPacket(token);
+                await setupHandler.ReciveUserIdsPacket(token);
             }
             p2pInfo.Instance.pings.Init();
             return Result.Success;

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -1437,7 +1437,7 @@ namespace SynicSugar.MatchMake {
             ConnectionSetupHandler setupHandler = new();
             Result canConnect = await setupHandler.WaitConnectPreparation(token, setupTimeoutSec * 1000); //Pass time as ms.
             if(canConnect != Result.Success){
-                return Result.ConnectEstablishFailed;
+                return canConnect;
             }
             //Host sends AllUserIds list, Guest Receives AllUserIds.
             if(p2pInfo.Instance.IsHost()){

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -573,7 +573,7 @@ namespace SynicSugar.MatchMake {
         /// <returns></returns>
         async UniTask<Result> TryJoinSearchResults(LobbySearch lobbySearch, List<AttributeData> userAttributes, bool isReconnecter = false, CancellationToken token = default(CancellationToken)){ 
             if (lobbySearch == null){
-                Logger.LogError("TryJoinSearchResults", "There is no LobbySearch.");
+                Logger.LogError("TryJoinSearchResults", "Could not get Lobby data by the process to find a lobby from EOS.");
                 return Result.NotFound;
             }
 
@@ -861,7 +861,6 @@ namespace SynicSugar.MatchMake {
                 if(p2pInfo.Instance.IsHost()){
                     ConnectionSetupHandler setupHandler = new();
                     setupHandler.SendUserList(UserId.GetUserId(info.TargetUserId));
-                    Logger.Log($"MemberStatusNotyfy", $"Send user list to {UserId.GetUserId(info.TargetUserId).ToMaskedString()}.");
                 }
                 p2pInfo.Instance.ConnectionNotifier.Connected(UserId.GetUserId(info.TargetUserId));
             }

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -849,14 +849,14 @@ namespace SynicSugar.MatchMake {
 
             }else if(info.CurrentStatus == LobbyMemberStatus.Left) {
                 Logger.Log($"MemberStatusNotyfy", $"{UserId.GetUserId(info.TargetUserId).ToMaskedString()} left from lobby.");
-                p2pInfo.Instance.userIds.RemoveUserId(info.TargetUserId);
+                p2pInfo.Instance.userIds.RemoveUserIdFromNonAllUserIds(info.TargetUserId);
                 p2pInfo.Instance.ConnectionNotifier.Leaved(UserId.GetUserId(info.TargetUserId), Reason.Left);
             }else if(info.CurrentStatus == LobbyMemberStatus.Disconnected){
                 Logger.Log($"MemberStatusNotyfy", $"{UserId.GetUserId(info.TargetUserId).ToMaskedString()} diconnect from lobby.");
-                p2pInfo.Instance.userIds.MoveTargetUserIdToLefts(info.TargetUserId);
+                p2pInfo.Instance.userIds.MoveUserIdToDisconnected(info.TargetUserId);
                 p2pInfo.Instance.ConnectionNotifier.Disconnected(UserId.GetUserId(info.TargetUserId), Reason.Disconnected);
             }else if(info.CurrentStatus == LobbyMemberStatus.Joined){
-                p2pInfo.Instance.userIds.MoveTargetUserIdToRemoteUsersFromLeft(info.TargetUserId);
+                p2pInfo.Instance.userIds.MoveUserIdToConnectedFromDisconnected(info.TargetUserId);
                 // Send Id list.
                 if(p2pInfo.Instance.IsHost()){
                     ConnectionSetupHandler setupHandler = new();

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Events/AsyncLobbyIDMethod.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Events/AsyncLobbyIDMethod.cs
@@ -23,7 +23,11 @@ namespace SynicSugar.MatchMake {
             Save += save;
             Delete += delete;
         }
-        internal void Clear(){
+        /// <summary>
+        /// Remove all events from the actions. <br />
+        /// Events are automatically cleared when they are no longer needed.
+        /// </summary>
+        public void Clear(){
             Save = null;
             Delete = null;
         }

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Events/LobbyIDMethod.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Events/LobbyIDMethod.cs
@@ -21,7 +21,11 @@ namespace SynicSugar.MatchMake {
             Save += save;
             Delete += delete;
         }
-        internal void Clear(){
+        /// <summary>
+        /// Remove all events from the actions. <br />
+        /// Events are automatically cleared when they are no longer needed.
+        /// </summary>
+        public void Clear(){
             Save = null;
             Delete = null;
         }

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Events/MatchMakingGUIEvents.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Events/MatchMakingGUIEvents.cs
@@ -131,7 +131,31 @@ namespace SynicSugar.MatchMake {
             /// </summary>
             Reconnect
         }
-        internal void Clear(){
+        /// <summary>
+        /// Remove all event and clear string data.
+        /// </summary>
+        internal void Reset(){
+            Clear();
+            
+        #if SYNICSUGAR_TMP
+            stateText = null;
+        #else
+            stateText = null;
+        #endif
+
+            Standby = string.Empty;
+            StartMatchmaking = string.Empty;
+            WaitForOpponents = string.Empty;
+            FinishMatchmaking = string.Empty;
+            ReadyForConnection = string.Empty;
+            TryToCancel = string.Empty;
+            StartReconnection = string.Empty;
+        }
+        /// <summary>
+        /// Remove all events from the actions. <br />
+        /// Events are automatically cleared when they are no longer needed.
+        /// </summary>
+        public void Clear(){
             DisableStart = null;
             EnableCancelKick = null;
             EnableHostConclude = null;

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Events/MemberUpdatedNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/Events/MemberUpdatedNotifier.cs
@@ -14,7 +14,11 @@ namespace SynicSugar.MatchMake {
         public void Register(Action<UserId> attributesUpdated){
             OnAttributesUpdated += attributesUpdated;
         }
-        internal void Clear(){
+        /// <summary>
+        /// Remove all events from the actions. <br />
+        /// Events are automatically cleared when they are no longer needed.
+        /// </summary>
+        public void Clear(){
             OnAttributesUpdated = null;
         }
         internal void MemberAttributesUpdated(UserId target){

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/MatchMakeManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/MatchMakeManager.cs
@@ -45,7 +45,7 @@ namespace SynicSugar.MatchMake {
                 lobbyIDMethod.Clear();
                 asyncLobbyIDMethod.Clear();
                 MemberUpdatedNotifier.Clear();
-                MatchMakingGUIEvents.Clear();
+                MatchMakingGUIEvents.Reset();
 
                 Instance = null;
             }

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/MatchMakeManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/MatchMakeManager.cs
@@ -534,6 +534,7 @@ namespace SynicSugar.MatchMake {
             }
             
             p2pInfo.Instance.userIds = new UserIds(isReconencter);
+            p2pInfo.Instance.ConnectionNotifier.Init();
 
             Result setupResult = await matchmakingCore.SetupP2PConnection(p2pSetupTimeoutSec, token);
 

--- a/SynicSugar/Assets/SynicSugar/Runtime/RTC/Events/AudioDeviceChangedNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/RTC/Events/AudioDeviceChangedNotifier.cs
@@ -11,7 +11,11 @@ namespace SynicSugar.RTC {
         public void Register(Action deviceChanged){
             OnDeviceChanged += deviceChanged;
         }
-        internal void Clear(){
+        /// <summary>
+        /// Remove all events from the actions. <br />
+        /// Events are automatically cleared when they are no longer needed.
+        /// </summary>
+        public void Clear(){
             OnDeviceChanged = null;
         }
         internal void DeviceChanged(){

--- a/SynicSugar/Assets/SynicSugar/Runtime/RTC/Events/ParticipantUpdatedNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/RTC/Events/ParticipantUpdatedNotifier.cs
@@ -17,7 +17,12 @@ namespace SynicSugar.RTC {
             OnStartTargetSpeaking += startSpeaking;
             OnStopTargetSpeaking += stopSpeaking;
         }
-        internal void Clear(){
+
+        /// <summary>
+        /// Remove all events from the actions. <br />
+        /// Events are automatically cleared when they are no longer needed
+        /// </summary>
+        public void Clear(){
             OnStartSpeaking = null;
             OnStopSpeaking = null;
             OnStartTargetSpeaking = null;

--- a/SynicSugar/Assets/SynicSugar/Runtime/RTC/RTCManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/RTC/RTCManager.cs
@@ -336,7 +336,10 @@ namespace SynicSugar.RTC {
                 }else{
                     CurrentLobby.Members[UserId.GetUserId(info.ParticipantId).ToString()].RTCState.IsLocalMute = !info.AudioEnabled;
                 }
-                Logger.Log("OnUpdateReceiving", $"the toggle is successful. CurrentStatus: {info.AudioEnabled} / Target: {UserId.GetUserId(info.ParticipantId).ToMaskedString()}");
+            #if SYNICSUGAR_LOG
+                string target = info.ParticipantId == null ? "All remote users" : UserId.GetUserId(info.ParticipantId).ToMaskedString();
+                Logger.Log("OnUpdateReceiving", $"the toggle is successful. CurrentStatus: {info.AudioEnabled} / Target: {target}");
+            #endif
                 result = (Result)info.ResultCode;
             }
         }
@@ -377,8 +380,10 @@ namespace SynicSugar.RTC {
                 }else{
                     CurrentLobby.Members[UserId.GetUserId(info.ParticipantId).ToString()].RTCState.LocalOutputedVolume =  info.Volume;
                 }
-
-                Logger.Log("OnUpdateParticipantVolume", $"volume change is successful. target: {UserId.GetUserId(info.ParticipantId).ToMaskedString()} / Volume:{info.Volume}");
+            #if SYNICSUGAR_LOG
+                string target = info.ParticipantId == null ? "All remote users" : UserId.GetUserId(info.ParticipantId).ToMaskedString();
+                Logger.Log("OnUpdateParticipantVolume", $"volume change is successful. Target: {target} / Volume:{info.Volume}");
+            #endif
                 result = (Result)info.ResultCode;
             }
         }

--- a/SynicSugar/Assets/SynicSugar/Runtime/Utilities/Logger.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/Utilities/Logger.cs
@@ -8,43 +8,43 @@ namespace SynicSugar
         [Conditional("SYNICSUGAR_LOG")] 
         internal static void Log(string methodName, string message)
         {
-            UnityEngine.Debug.Log($"[{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")}] [INFO] {methodName}: {message}");
+            UnityEngine.Debug.Log($"[SynicSugar INFO] [{DateTime.Now.ToString("HH:mm:ss.fff")}] {methodName}: {message}");
         }
         [Conditional("SYNICSUGAR_LOG")] 
         internal static void Log(string methodName, Result result)
         {
-            UnityEngine.Debug.Log($"[{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")}] [INFO] {methodName} Result: {result}");
+            UnityEngine.Debug.Log($"[SynicSugar INFO] [{DateTime.Now.ToString("HH:mm:ss.fff")}] {methodName} Result: {result}");
         }
         [Conditional("SYNICSUGAR_LOG")] 
         internal static void Log(string methodName, string message, Result result)
         {
-            UnityEngine.Debug.Log($"[{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")}] [INFO] {methodName}: {message} Result: {result}");
+            UnityEngine.Debug.Log($"[SynicSugar INFO] [{DateTime.Now.ToString("HH:mm:ss.fff")}] {methodName}: {message} Result: {result}");
         }
 
         internal static void LogWarning(string methodName, string message)
         {
-            UnityEngine.Debug.LogWarning($"[{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")}] [WARN] {methodName}: {message}");
+            UnityEngine.Debug.LogWarning($"[SynicSugar WARN] [{DateTime.Now.ToString("HH:mm:ss.fff")}] {methodName}: {message}");
         }
         internal static void LogWarning(string methodName, Result result)
         {
-            UnityEngine.Debug.LogWarning($"[{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")}] [WARN] {methodName} Result: {result}");
+            UnityEngine.Debug.LogWarning($"[SynicSugar WARN] [{DateTime.Now.ToString("HH:mm:ss.fff")}] {methodName} Result: {result}");
         }
         internal static void LogWarning(string methodName, string message, Result result)
         {
-            UnityEngine.Debug.LogWarning($"[{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")}] [WARN] {methodName}: {message} Result: {result}");
+            UnityEngine.Debug.LogWarning($"[SynicSugar WARN] [{DateTime.Now.ToString("HH:mm:ss.fff")}] {methodName}: {message} Result: {result}");
         }
         
         internal static void LogError(string methodName, string message)
         {
-            UnityEngine.Debug.LogError($"[{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")}] [ERROR] {methodName}: {message}");
+            UnityEngine.Debug.LogError($"[SynicSugar ERROR] [{DateTime.Now.ToString("HH:mm:ss.fff")}] {methodName}: {message}");
         }
         internal static void LogError(string methodName, Result result)
         {
-            UnityEngine.Debug.LogError($"[{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")}] [ERROR] {methodName} Result: {result}");
+            UnityEngine.Debug.LogError($"[SynicSugar ERROR] [{DateTime.Now.ToString("HH:mm:ss.fff")}] {methodName} Result: {result}");
         }
         internal static void LogError(string methodName, string message, Result result)
         {
-            UnityEngine.Debug.LogError($"[{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")}] [ERROR] {methodName}: {message} Result: {result}");
+            UnityEngine.Debug.LogError($"[SynicSugar ERROR] [{DateTime.Now.ToString("HH:mm:ss.fff")}] {methodName}: {message} Result: {result}");
         }
     }
 }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/PacketQueueInformation.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/PacketQueueInformation.cs
@@ -1,0 +1,29 @@
+namespace SynicSugar.P2P {
+    public class PacketQueueInformation
+    {
+        /// <summary>
+        /// The maximum size in bytes of the incoming packet queue
+        /// </summary>
+        public ulong IncomingPacketQueueMaxSizeBytes { get; internal set; }
+        /// <summary>
+        /// The current size in bytes of the incoming packet queue
+        /// </summary>
+        public ulong IncomingPacketQueueCurrentSizeBytes { get; internal set; }
+        /// <summary>
+        /// The current number of queued packets in the incoming packet queue
+        /// </summary>
+        public ulong IncomingPacketQueueCurrentPacketCount { get; internal set; }
+        /// <summary>
+        /// The maximum size in bytes of the outgoing packet queue
+        /// </summary>
+        public ulong OutgoingPacketQueueMaxSizeBytes { get; internal set; }
+        /// <summary>
+        /// The current size in bytes of the outgoing packet queue
+        /// </summary>
+        public ulong OutgoingPacketQueueCurrentSizeBytes { get; internal set; }
+        /// <summary>
+        /// The current amount of queued packets in the outgoing packet queue
+        /// </summary>
+        public ulong OutgoingPacketQueueCurrentPacketCount { get; internal set; }
+    }
+}

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/PacketQueueInformation.cs.meta
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/PacketQueueInformation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 479ee61bf4d024298ad992fb43a7099a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/SessionCore.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/SessionCore.cs
@@ -446,5 +446,12 @@ namespace SynicSugar.Base {
         void INetworkCore.GetPong(string id, ArraySegment<byte> utc){
             p2pInfo.Instance.pings.GetPong(id, utc);
         }
+
+        /// <summary>
+        /// Get the packet queue information.
+        /// </summary>
+        /// <param name="Info">The object to return the result.</param>
+        /// <returns></returns>
+        public abstract Result GetPacketQueueInfo(out PacketQueueInformation Info);
     }
 }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/SessionCore.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/SessionCore.cs
@@ -127,7 +127,7 @@ namespace SynicSugar.Base {
                 Logger.LogWarning("RestartConnections", IsConnected ?  "The connection is already active. No action taken." : "Cannot restart because the user is not in an online session.");
                 return Result.InvalidAPICall;
             }
-            Result result = RestartConnections();
+            Result result = InitiateConnection();
 
             if(result == Result.Success){
                 IsConnected = true;
@@ -135,7 +135,6 @@ namespace SynicSugar.Base {
             }
             return result;
         }
-        protected abstract Result RestartConnections();
 
         /// <summary>
         /// Use this from hub not to call some methods in Main-Assembly from SynicSugar.dll.<br />

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/SessionCore.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/SessionCore.cs
@@ -381,6 +381,18 @@ namespace SynicSugar.Base {
             return result;
         }
         protected abstract Result InitiateConnection(bool checkInitConnect);
+
+        /// <summary>
+        /// Prep for p2p connections with disconencted user.
+        /// </summary>
+        /// <param name="targetId">Reconnected user's id</param>
+        /// <returns></returns>
+        public Result OpenConnection(UserId targetId){
+            Result result = AcceptConnection(targetId);
+
+            return result;
+        }
+        protected abstract Result AcceptConnection(UserId targetId);
 #endregion
 #region Disconnect
         /// <summary>

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/UserIds.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/UserIds.cs
@@ -50,19 +50,43 @@ namespace SynicSugar.P2P {
         internal void OverwriteAllUserIdsWithOrdered(BasicInfo data){
             Logger.Log("OverwriteAllUserIdsWithOrdered", $"Overwrite AllUserIds with {data.userIds.Count} users. , isReconencter: {isJustReconnected}");
 
-            AllUserIds.Clear();
             //Change order　to same in host local.
-            foreach(var id in data.userIds){
-                AllUserIds.Add(UserId.GenerateFromStringForReconnecter(id));
+            if(AllUserIds.Count == data.userIds.Count)
+            {
+                for (int i = 0; i < data.userIds.Count; i++)
+                {
+                    AllUserIds[i] = UserId.GenerateFromStringForReconnecter(data.userIds[i]);
+                }
+            }
+            else
+            {
+                AllUserIds.Clear();
+                foreach(var id in data.userIds)
+                {
+                    AllUserIds.Add(UserId.GenerateFromStringForReconnecter(id));
+                }
             }
 
             if(!isJustReconnected){
                 return;
             }
             //Create current lefted user list
-            foreach(var index in data.disconnectedUserIndexes){
-                DisconnectedUserIds.Add(AllUserIds[index]);
+            if(DisconnectedUserIds.Count == data.disconnectedUserIndexes.Count)
+            {
+                for (int i = 0; i < data.disconnectedUserIndexes.Count; i++)
+                {
+                    DisconnectedUserIds[i] = AllUserIds[data.disconnectedUserIndexes[i]];
+                }
             }
+            else
+            {
+                DisconnectedUserIds.Clear();
+                foreach(var index in data.disconnectedUserIndexes)
+                {
+                    DisconnectedUserIds.Add(AllUserIds[index]);
+                }
+            }
+
             //Complement disconnected users.
             foreach(var id in DisconnectedUserIds){
                 CurrentAllUserIds.Add(id);

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/UserIds.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/UserIds.cs
@@ -44,11 +44,11 @@ namespace SynicSugar.P2P {
             isJustReconnected = false;
         }
         /// <summary>
-        /// Update AllUserIds with Host's sending data.
+        /// Update UserId Listｓ with Host's sending data.
         /// </summary>
         /// <param name="data">Contains All UserIds and Disconnected user indexes</param>
-        internal void OverwriteAllUserIdsWithOrdered(BasicInfo data){
-            Logger.Log("OverwriteAllUserIdsWithOrdered", $"Overwrite AllUserIds with {data.userIds.Count} users. , isReconencter: {isJustReconnected}");
+        internal void OverwriteUserIdsWithHostData(BasicInfo data){
+            Logger.Log("OverwriteUserIdsWithHostData", $"Update lists with {data.userIds.Count} users. , isReconencter: {isJustReconnected}");
 
             //Change order　to same in host local.
             if(AllUserIds.Count == data.userIds.Count)
@@ -87,7 +87,7 @@ namespace SynicSugar.P2P {
                 }
             }
 
-            //Complement disconnected users.
+            //Complement disconnected users. ここの処理の意図を考える。オーバーライトなのでもしかするとRemoveなどの可能性もある
             foreach(var id in DisconnectedUserIds){
                 CurrentAllUserIds.Add(id);
             }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/UserIds.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/UserIds.cs
@@ -87,8 +87,9 @@ namespace SynicSugar.P2P {
                 }
             }
 
-            //Complement disconnected users. ここの処理の意図を考える。オーバーライトなのでもしかするとRemoveなどの可能性もある
-            foreach(var id in DisconnectedUserIds){
+            //Complement disconnected users. CurrentAllUserIds is Current lobby users + disconnected users.
+            foreach(var id in DisconnectedUserIds)
+            {
                 CurrentAllUserIds.Add(id);
             }
             //For the case this user did not have data of CurrentSessionStartUTC.

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/UserIds.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Core/UserIds.cs
@@ -100,37 +100,40 @@ namespace SynicSugar.P2P {
         /// Remove user ID when the user leaves lobby.<br />
         /// </summary>
         /// <param name="targetId"></param>
-        internal void RemoveUserId(ProductUserId targetId){
-            Logger.Log("RemoveUserId", $"Remove {UserId.GetUserId(targetId).ToMaskedString()}");
+        internal void RemoveUserIdFromNonAllUserIds(ProductUserId targetId){
+            Logger.Log("RemoveUserIdFromNonAllUserIds", $"Deactivate {UserId.GetUserId(targetId).ToMaskedString()} on current session.");
             UserId userId = UserId.GetUserId(targetId);
+            p2pInfo.Instance.pings.pingInfo.Remove(userId.ToString());
+
             RemoteUserIds.Remove(userId);
             CurrentAllUserIds.Remove(userId);
             CurrentConnectedUserIds.Remove(userId);
-            p2pInfo.Instance.pings.pingInfo.Remove(userId.ToString());
         }
         /// <summary>
         /// Move UserID from RemotoUserIDs to LeftUsers not to SendPacketToALl in vain.<br />
         /// </summary>
         /// <param name="targetId"></param>
-        internal void MoveTargetUserIdToLefts(ProductUserId targetId){
-            Logger.Log("MoveTargetUserIdToLefts", $"Move {UserId.GetUserId(targetId).ToMaskedString()}");
+        internal void MoveUserIdToDisconnected(ProductUserId targetId){
+            Logger.Log("MoveUserIdToDisconnected", $"Move {UserId.GetUserId(targetId).ToMaskedString()} to DisconnectedUserIds.");
             UserId userId = UserId.GetUserId(targetId);
+            p2pInfo.Instance.pings.pingInfo[userId.ToString()].Ping = -1;
+
             RemoteUserIds.Remove(userId);
             CurrentConnectedUserIds.Remove(userId);
             DisconnectedUserIds.Add(userId);
-            p2pInfo.Instance.pings.pingInfo[userId.ToString()].Ping = -1;
         }
         /// <summary>
         /// Move UserID to RemotoUserIDs from LeftUsers on reconnect.
         /// </summary>
         /// <param name="targetId"></param>
         /// <returns></returns>
-        internal void MoveTargetUserIdToRemoteUsersFromLeft(ProductUserId targetId){
-            Logger.Log("MoveTargetUserIdToRemoteUsersFromLeft", $"Move {UserId.GetUserId(targetId).ToMaskedString()}");
+        internal void MoveUserIdToConnectedFromDisconnected(ProductUserId targetId){
+            Logger.Log("MoveUserIdToConnectedFromDisconnected", $"Move {UserId.GetUserId(targetId).ToMaskedString()} from DisconnectedUserIds.");
             UserId userId = UserId.GetUserId(targetId);
+
             DisconnectedUserIds.Remove(userId);
-            CurrentConnectedUserIds.Add(userId);
             RemoteUserIds.Add(userId);
+            CurrentConnectedUserIds.Add(userId);
         }
     }
 }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
@@ -1,7 +1,6 @@
 using PlayEveryWare.EpicOnlineServices;
 using Epic.OnlineServices;
 using Epic.OnlineServices.P2P;
-using UnityEngine;
 using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
@@ -375,7 +375,7 @@ namespace SynicSugar.P2P {
         
         if(data.ConnectionType == ConnectionEstablishedType.NewConnection &&
             p2pInfo.Instance.userIds.RemoteUserIds.Contains(UserId.GetUserId(data.RemoteUserId))){
-            p2pInfo.Instance.ConnectionNotifier.OnEstablished();
+            p2pInfo.Instance.ConnectionNotifier.OnEstablished(UserId.GetUserId(data.RemoteUserId));
             return;
         }
     }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
@@ -113,7 +113,7 @@ namespace SynicSugar.P2P {
             }
             id = UserId.GetUserId(productUserId);
         #if SYNICSUGAR_PACKETINFO
-            Debug.Log($"ReceivePacket: ch: {ch} from {id.ToMaskedString()} / packet size {bytesWritten} / payload {payload.ToHexString()}");
+            UnityEngine.Debug.Log($"ReceivePacket: ch: {ch} from {id.ToMaskedString()} / packet size {bytesWritten} / payload {payload.ToHexString()}");
         #endif
             return true;
         }
@@ -150,7 +150,7 @@ namespace SynicSugar.P2P {
             }
             id = UserId.GetUserId(productUserId);
         #if SYNICSUGAR_PACKETINFO
-            Debug.Log($"ReceivePacket(Synic): ch: {ch}  from {id.ToMaskedString()} / packet size {bytesWritten} / payload {payload.ToHexString()}");
+            UnityEngine.Debug.Log($"ReceivePacket(Synic): ch: {ch}  from {id.ToMaskedString()} / packet size {bytesWritten} / payload {payload.ToHexString()}");
         #endif
             return true;
         }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
@@ -63,7 +63,7 @@ namespace SynicSugar.P2P {
             RemoveNotifyAndCloseConnection();
             
             GetPacketQueueInfoOptions options = new GetPacketQueueInfoOptions();
-            Epic.OnlineServices.P2P.PacketQueueInfo info = new Epic.OnlineServices.P2P.PacketQueueInfo();
+            PacketQueueInfo info = new PacketQueueInfo();
             P2PHandle.GetPacketQueueInfo(ref options, out info);
 
             while (info.IncomingPacketQueueCurrentPacketCount > 0){

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
@@ -220,7 +220,7 @@ namespace SynicSugar.P2P {
         // This function will only be called if the connection has not been accepted yet.
         void OnIncomingConnectionRequest(ref OnIncomingConnectionRequestInfo data){
             if (!(bool)data.SocketId?.SocketName.Equals(ScoketName)){
-                Logger.LogError("OnIncomingConnectionRequest", "unknown socket id. This peer should be no lobby member.");
+                Logger.LogError("OnIncomingConnectionRequest", "This packet uses diffrent socket id with the current session. This peer is likely not a lobby member.");
                 return;
             }
 
@@ -312,6 +312,29 @@ namespace SynicSugar.P2P {
             }
             Logger.Log("AcceptAllConenctions", $"Accept the connection with {id.ToMaskedString()}");
         }
+    }
+    /// <summary>
+    /// For reconnection process. <br />
+    /// Accept the connection with the disconnected user. <br />
+    /// EOS doesn't need this process, because the connection is automatically restored. This is for the other backend in the future.
+    /// </summary>
+    /// <param name="targetId"></param>
+    /// <returns></returns>
+    protected override Result AcceptConnection(UserId targetId){
+        AcceptConnectionOptions options = new AcceptConnectionOptions(){
+            LocalUserId = SynicSugarManger.Instance.LocalUserId.AsEpic,
+            RemoteUserId = targetId.AsEpic,
+            SocketId = SocketId
+        };
+        
+        Result result = (Result)P2PHandle.AcceptConnection(ref options);
+
+        if (result != Result.Success){
+            Logger.LogError("AcceptConnection", $"error while accepting connection for {targetId.ToMaskedString()}.", result);
+            return result;
+        }
+        Logger.Log("AcceptConnection", $"Accept the connection with {targetId.ToMaskedString()}");
+        return Result.Success;
     }
 #endregion
 #region Early Disconnected Notify

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
@@ -112,10 +112,10 @@ namespace SynicSugar.P2P {
 #endif
                 return false; //No packet
             }
-        // #if SYNICSUGAR_PACKETINFO
-        //     Debug.Log($"ReceivePacket: ch: {ch} from {id.ToMaskedString()} / packet size {bytesWritten} / payload {payload.ToHexString()}");
-        // #endif
             id = UserId.GetUserId(productUserId);
+        #if SYNICSUGAR_PACKETINFO
+            Debug.Log($"ReceivePacket: ch: {ch} from {id.ToMaskedString()} / packet size {bytesWritten} / payload {payload.ToHexString()}");
+        #endif
             return true;
         }
         /// <summary>
@@ -149,10 +149,10 @@ namespace SynicSugar.P2P {
 #endif
                 return false; //No packet
             }
+            id = UserId.GetUserId(productUserId);
         #if SYNICSUGAR_PACKETINFO
             Debug.Log($"ReceivePacket(Synic): ch: {ch}  from {id.ToMaskedString()} / packet size {bytesWritten} / payload {payload.ToHexString()}");
         #endif
-            id = UserId.GetUserId(productUserId);
             return true;
         }
     
@@ -235,7 +235,9 @@ namespace SynicSugar.P2P {
 
             if (result != ResultE.Success){
                 Logger.LogError("OnIncomingConnectionRequest", "error while accepting connection.", (Result)result);
+                return;
             }
+            Logger.Log("OnIncomingConnectionRequest", $"Accept the connection with {UserId.GetUserId(data.RemoteUserId).ToMaskedString()}");
         }
         void RemoveNotifyPeerConnectionRequest(){
             P2PHandle.RemoveNotifyPeerConnectionRequest(RequestNotifyId);
@@ -253,10 +255,8 @@ namespace SynicSugar.P2P {
         AcceptAllConenctions();
 
         if(checkInitConnect || p2pConfig.Instance.UseDisconnectedEarlyNotify){
-            AddNotifyPeerConnectionEstablished();
-        }
-        if(checkInitConnect){
             UpdatePacketOptions();
+            AddNotifyPeerConnectionEstablished();
         }
         if(p2pConfig.Instance.UseDisconnectedEarlyNotify){
             AddNotifyPeerConnectionInterrupted();
@@ -297,9 +297,10 @@ namespace SynicSugar.P2P {
     /// </summary>
     void AcceptAllConenctions(){
         ResultE result = ResultE.Success;
+        ProductUserId localUserId = p2pInfo.Instance.userIds.LocalUserId.AsEpic;
         foreach(var id in p2pInfo.Instance.userIds.RemoteUserIds){
             AcceptConnectionOptions options = new AcceptConnectionOptions(){
-                LocalUserId = p2pInfo.Instance.userIds.LocalUserId.AsEpic,
+                LocalUserId = localUserId,
                 RemoteUserId = id.AsEpic,
                 SocketId = SocketId
             };
@@ -310,6 +311,7 @@ namespace SynicSugar.P2P {
                 Logger.LogError("AcceptAllConenctions", $"error while accepting connection for {id.ToMaskedString()}.", (Result)result);
                 break;
             }
+            Logger.Log("AcceptAllConenctions", $"Accept the connection with {id.ToMaskedString()}");
         }
     }
 #endregion

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/EOS/EOSSessionManager.cs
@@ -73,12 +73,6 @@ namespace SynicSugar.P2P {
             ((INetworkCore)this).StopPacketReceiver();
             return Result.Success;
         }
-        /// <summary>
-        /// Prepare to receive in advance. If user sent packets, it can open to get packets for a socket id without this.
-        /// </summary>
-        protected override Result RestartConnections(){
-            return InitiateConnection();
-        }
         
         /// <summary>
         /// To get Packetｓ.
@@ -310,7 +304,7 @@ namespace SynicSugar.P2P {
                 Logger.LogError("AcceptAllConenctions", $"error while accepting connection for {id.ToMaskedString()}.", (Result)result);
                 break;
             }
-            Logger.Log("AcceptAllConenctions", $"Accept the connection with {id.ToMaskedString()}");
+            Logger.Log("AcceptAllConenctions", $"Accept the connection from {id.ToMaskedString()}");
         }
     }
     /// <summary>

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
@@ -156,7 +156,7 @@ namespace SynicSugar.P2P {
         internal void OnEstablished(UserId id){
             establishedMemberCounts++;
             completeConnectPreparetion = p2pInfo.Instance.userIds.RemoteUserIds.Count == establishedMemberCounts;
-            Logger.Log("OnEstablished", $"A connection has been established with {id.ToMaskedString()} / CompleteConnectPreparetion: {completeConnectPreparetion}");
+            Logger.Log("OnEstablished", $"A connection has been established with {id.ToMaskedString()} / CurrentConnections: {establishedMemberCounts} / {p2pInfo.Instance.userIds.RemoteUserIds.Count}");
         }
     }
 }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
@@ -71,14 +71,17 @@ namespace SynicSugar.P2P {
             OnTargetEarlyDisconnected += earlyDisconnected;
             OnTargetRestored += restored;
         }
+        internal void Init(){
+            establishedMemberCounts = 0;
+            completeConnectPreparetion = false;
+        }
         /// <summary>
         /// Remove all events and init all variables. <br />
         /// NetworkObject can be used without being initialized, so called this on the last of the session.
         /// </summary>
         internal void Reset(){
             Clear();
-            establishedMemberCounts = 0;
-            completeConnectPreparetion = false;
+            Init();
         }
         /// <summary>
         /// Remove all events from the actions. <br />
@@ -150,8 +153,9 @@ namespace SynicSugar.P2P {
         }
         private int establishedMemberCounts;
         internal bool completeConnectPreparetion; 
-        internal void OnEstablished(){
+        internal void OnEstablished(UserId id){
             establishedMemberCounts++;
+            Logger.Log("OnEstablished", $"A connection has been established with {id.ToMaskedString()}");
             completeConnectPreparetion = p2pInfo.Instance.userIds.RemoteUserIds.Count == establishedMemberCounts;
         }
     }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
@@ -12,23 +12,31 @@ namespace SynicSugar.P2P {
 
         /// <summary>
         /// Invoke when another user leaves.<br />
+        /// To remove all event handlers at once, call `Clear()`. <br />
+        /// To remove a specific handler, use the `-=` operator.
         /// </summary>
         public event Action<UserId> OnTargetLeaved;
         /// <summary>
         /// Invoke when another user disconnects unexpectedly.<br />
-        /// This has a lag of about 5-10 seconds after a user downs in its local.
+        /// This has a lag of about 5-10 seconds after a user downs in its local.<br />
+        /// To remove all event handlers at once, call `Clear()`. <br />
+        /// To remove a specific handler, use the `-=` operator.
         /// </summary>
         public event Action<UserId> OnTargetDisconnected;
         /// <summary>
         /// Invoke when a user re-connects after matchmaking.<br />
-        /// For returnee and newcomer
+        /// For returnee and newcomer<br />
+        /// To remove all event handlers at once, call `Clear()`. <br />
+        /// To remove a specific handler, use the `-=` operator.
         /// </summary>
         public event Action<UserId> OnTargetConnected;
         
         /// <summary>
         /// Invoke when a connection is interrupted with another peer. <br />
         /// The connection is attempted to be restored, and if that's failed, "Diconnected" is fired.<br />
-        /// This notification is early, but this doesn't means just that other user is disconnected.
+        /// This notification is early, but this doesn't means just that other user is disconnected.<br />
+        /// To remove all event handlers at once, call `Clear()`. <br />
+        /// To remove a specific handler, use the `-=` operator.
         /// </summary>
         public event Action<UserId> OnTargetEarlyDisconnected;
         
@@ -39,14 +47,16 @@ namespace SynicSugar.P2P {
         public event Action<UserId> OnTargetRestored;
         
         /// <summary>
-        /// Invoked when the Lobby is closed and the local user is removed　￥ from the Lobby.<br />
+        /// Invoked when the Lobby is closed and the local user is removed　from the Lobby.<br />
         /// Possible reasons include:<br />
         /// - Disconnected: An unexpected disconnection occurred.<br />
         /// - LobbyClosed: The host closed the Lobby.<br />
         /// - Kicked: The local user was kicked from the Lobby by Host.<br />
         /// Note: This does not include the process for destroying the NetworkManager. If it is no longer needed, please call `Destroy(MatchMakeManager.Instance.gameObject);`. <br />
         /// The LobbyID is deleted only if the Lobby was closed by the host (LobbyClosed). <br />
-        /// If disconnected or kicked, can use `MatchMaking.Instance.ReconnectLobby()` to rejoin.
+        /// If disconnected or kicked, can use `MatchMaking.Instance.ReconnectLobby()` to rejoin.　<br />
+        /// To remove all event handlers at once, call `Clear()`. <br />
+        /// To remove a specific handler, use the `-=` operator.
         /// </summary>
         public event Action<Reason> OnLobbyClosed;
 
@@ -61,15 +71,25 @@ namespace SynicSugar.P2P {
             OnTargetEarlyDisconnected += earlyDisconnected;
             OnTargetRestored += restored;
         }
-        internal void Clear(){
+        /// <summary>
+        /// Remove all events and init all variables. <br />
+        /// NetworkObject can be used without being initialized, so called this on the last of the session.
+        /// </summary>
+        internal void Reset(){
+            Clear();
+            establishedMemberCounts = 0;
+            completeConnectPreparetion = false;
+        }
+        /// <summary>
+        /// Remove all events from the actions.
+        /// </summary>
+        public void Clear(){
             OnTargetLeaved = null;
             OnTargetDisconnected = null;
             OnTargetConnected = null;
             OnTargetEarlyDisconnected = null;
             OnTargetRestored = null;
             OnLobbyClosed = null;
-            establishedMemberCounts = 0;
-            completeConnectPreparetion = false;
         }
         /// <summary>
         /// Invoked when someone leaves the lobby for reasons other than Leave.

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
@@ -155,8 +155,8 @@ namespace SynicSugar.P2P {
         internal bool completeConnectPreparetion; 
         internal void OnEstablished(UserId id){
             establishedMemberCounts++;
-            Logger.Log("OnEstablished", $"A connection has been established with {id.ToMaskedString()}");
             completeConnectPreparetion = p2pInfo.Instance.userIds.RemoteUserIds.Count == establishedMemberCounts;
+            Logger.Log("OnEstablished", $"A connection has been established with {id.ToMaskedString()} / CompleteConnectPreparetion: {completeConnectPreparetion}");
         }
     }
 }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
@@ -81,7 +81,8 @@ namespace SynicSugar.P2P {
             completeConnectPreparetion = false;
         }
         /// <summary>
-        /// Remove all events from the actions.
+        /// Remove all events from the actions. <br />
+        /// Events are automatically cleared when they are no longer needed.
         /// </summary>
         public void Clear(){
             OnTargetLeaved = null;

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/ConnectionNotifier.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS0414 //The field is assigned but its value is never used
 using System;
+using SynicSugar.MatchMake;
 
 namespace SynicSugar.P2P {
     /// <summary>
@@ -145,17 +146,33 @@ namespace SynicSugar.P2P {
         /// <summary>
         /// This Local user can't connect to lobby anymore.
         /// </summary>
-        /// <param name="id"></param>
         /// <param name="reason"></param>
         internal void Closed(Reason reason){
             ClosedReason = reason;
             OnLobbyClosed?.Invoke(reason);
         }
         private int establishedMemberCounts;
-        internal bool completeConnectPreparetion; 
+        internal bool completeConnectPreparetion;
+        /// <summary>
+        /// For new connection or connection from complete disconnection.
+        /// </summary>
+        /// <param name="id"></param>
         internal void OnEstablished(UserId id){
-            establishedMemberCounts++;
-            completeConnectPreparetion = p2pInfo.Instance.userIds.RemoteUserIds.Count == establishedMemberCounts;
+            if(!SynicSugarManger.Instance.State.IsInSession)
+            {
+                establishedMemberCounts++;
+                completeConnectPreparetion = p2pInfo.Instance.userIds.RemoteUserIds.Count == establishedMemberCounts;
+            }
+            else
+            {
+                // Send Id list.
+                if(p2pInfo.Instance.IsHost()){
+                    ConnectionSetupHandler setupHandler = new();
+                    setupHandler.SendUserList(id);
+                }
+                Connected(id);
+            }
+
             Logger.Log("OnEstablished", $"A connection has been established with {id.ToMaskedString()} / CurrentConnections: {establishedMemberCounts} / {p2pInfo.Instance.userIds.RemoteUserIds.Count}");
         }
     }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/SyncSnyicNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/SyncSnyicNotifier.cs
@@ -24,7 +24,8 @@ namespace SynicSugar.P2P {
             includeDisconnectedData = false;
         }
         /// <summary>
-        /// Remove all events from the actions.
+        /// Remove all events from the actions. <br />
+        /// Events are automatically cleared when they are no longer needed.
         /// </summary>
         public void Clear(){
             OnSyncedSynic = null;

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/SyncSnyicNotifier.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/Events/SyncSnyicNotifier.cs
@@ -12,7 +12,21 @@ namespace SynicSugar.P2P {
         public void Register(Action syncedSynic){
             OnSyncedSynic += syncedSynic;
         }
-        internal void Clear(){
+        /// <summary>
+        /// Remove all events and init all variables. <br />
+        /// NetworkObject can be used without being initialized, so called this on the last of the session.
+        /// </summary>
+        internal void Reset(){
+            LastSyncedUserId = SynicSugarManger.Instance.LocalUserId;
+            LastSyncedPhase = 0;
+            ReceivedUsers.Clear();
+            _receivedAllSyncSynic = false;
+            includeDisconnectedData = false;
+        }
+        /// <summary>
+        /// Remove all events from the actions.
+        /// </summary>
+        public void Clear(){
             OnSyncedSynic = null;
         }
 

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/PacketReceive/PacketReceiveTiming.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/PacketReceive/PacketReceiveTiming.cs
@@ -1,8 +1,19 @@
-/// <summary>
-/// This is the same timing with Unity each Update.
-/// </summary>
-public enum PacketReceiveTiming {
-    FixedUpdate,
-    Update,
-    LateUpdate
+namespace SynicSugar.P2P{
+    /// <summary>
+    /// This is the same timing with Unity each Update.
+    /// </summary>
+    public enum PacketReceiveTiming {
+        /// <summary>
+        /// Process in FixedUpdate (Physics updates)
+        /// </summary>
+        FixedUpdate,
+        /// <summary>
+        /// Process in Update (Frame-based updates)
+        /// </summary>
+        Update,
+        /// <summary>
+        /// Process in LateUpdate (After all Update calls)
+        /// </summary>
+        LateUpdate
+    }
 }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/p2pInfo.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/p2pInfo.cs
@@ -28,7 +28,7 @@ namespace SynicSugar.P2P {
             if( Instance == this ) {
                 UserId.CacheClear();
                 ConnectionNotifier.Reset();
-                SyncSnyicNotifier.Clear();
+                SyncSnyicNotifier.Reset();
 
                 Instance = null;
             }
@@ -44,7 +44,7 @@ namespace SynicSugar.P2P {
             CurrentSessionStartUTC = DateTime.MinValue;
             UserId.CacheClear();
             ConnectionNotifier.Reset();
-            SyncSnyicNotifier.Clear();
+            SyncSnyicNotifier.Reset();
         }
         /// <summary>
         /// Set reference of some manager classes.

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/p2pInfo.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/p2pInfo.cs
@@ -27,7 +27,7 @@ namespace SynicSugar.P2P {
         void OnDestroy() {
             if( Instance == this ) {
                 UserId.CacheClear();
-                ConnectionNotifier.Clear();
+                ConnectionNotifier.Reset();
                 SyncSnyicNotifier.Clear();
 
                 Instance = null;
@@ -43,7 +43,7 @@ namespace SynicSugar.P2P {
             lastTargetRPCInfo = new();
             CurrentSessionStartUTC = DateTime.MinValue;
             UserId.CacheClear();
-            ConnectionNotifier.Clear();
+            ConnectionNotifier.Reset();
             SyncSnyicNotifier.Clear();
         }
         /// <summary>

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/p2pInfo.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/p2pInfo.cs
@@ -28,7 +28,6 @@ namespace SynicSugar.P2P {
             if( Instance == this ) {
                 UserId.CacheClear();
                 ConnectionNotifier.Reset();
-                SyncSnyicNotifier.Reset();
 
                 Instance = null;
             }

--- a/SynicSugar/Assets/SynicSugar/Runtime/p2p/p2pInfo.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/p2p/p2pInfo.cs
@@ -280,6 +280,14 @@ namespace SynicSugar.P2P {
         }
     #endregion
         /// <summary>
+        /// Get the information related to the current state of the packet queues. 
+        /// </summary>
+        /// <param name="packetQueueInformation"></param>
+        /// <returns></returns>
+        public Result GetPacketQueueInfo(out PacketQueueInformation packetQueueInformation){
+            return sessionCore.GetPacketQueueInfo(out packetQueueInformation);
+        }
+        /// <summary>
         /// the last byte array sent with RPC that record data.
         /// </summary>
         public byte[] LastRPCPayload => lastRpcInfo.payload;

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/DebugCanvas.prefab
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/DebugCanvas.prefab
@@ -33,7 +33,6 @@ RectTransform:
   m_Children:
   - {fileID: 6763982644950810166}
   m_Father: {fileID: 6132300884473272720}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -170,7 +169,6 @@ RectTransform:
   - {fileID: 1214346956970606445}
   - {fileID: 5210668300952844999}
   m_Father: {fileID: 6132300884961527158}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -276,7 +274,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6132300885504994657}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -334,6 +331,7 @@ GameObject:
   - component: {fileID: 6132300884961527156}
   - component: {fileID: 6132300884961527155}
   - component: {fileID: 3297297866785036516}
+  - component: {fileID: 3121482771997366419}
   m_Layer: 5
   m_Name: DebugCanvas
   m_TagString: Untagged
@@ -355,7 +353,6 @@ RectTransform:
   m_Children:
   - {fileID: 6132300884473272720}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -379,7 +376,9 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 250
   m_TargetDisplay: 0
@@ -436,6 +435,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   debug: {fileID: 6132300886041938434}
+--- !u!114 &3121482771997366419
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6132300884961527153}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4dd84cac8b27549bba33c905a1653dc6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6132300885045986100
 GameObject:
   m_ObjectHideFlags: 0
@@ -469,7 +480,6 @@ RectTransform:
   m_Children:
   - {fileID: 6132300885638744373}
   m_Father: {fileID: 6132300884473272720}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -557,7 +567,6 @@ RectTransform:
   m_Children:
   - {fileID: 6132300884947093539}
   m_Father: {fileID: 6132300885885006419}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -594,7 +603,6 @@ RectTransform:
   m_Children:
   - {fileID: 6132300886041938433}
   m_Father: {fileID: 6132300885045986101}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -634,7 +642,6 @@ RectTransform:
   m_Children:
   - {fileID: 6132300885504994657}
   m_Father: {fileID: 6132300884473272720}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -722,7 +729,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 6132300884947093540}
   m_HandleRect: {fileID: 6132300884947093539}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -759,7 +766,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6132300885638744373}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -839,7 +845,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5210668300952844999}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -921,7 +926,6 @@ RectTransform:
   m_Children:
   - {fileID: 4700089747044896238}
   m_Father: {fileID: 6132300884473272720}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1053,7 +1057,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1214346956970606445}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/PacketMonitor.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/PacketMonitor.cs
@@ -30,31 +30,44 @@ namespace SynicSugar.Samples {
             FixedUpdate,
             LateUpdate
         }
-        public UpdateTiming updateTiming { get; private set; }  = UpdateTiming.None;
+        public UpdateTiming updateTiming { get; private set; } = UpdateTiming.None;
+        private bool incomingIsZero, outgoingIsZero ;
         public void SetUpdateTiming(UpdateTiming updateTiming)
         {
+            incomingIsZero = false;
+            outgoingIsZero = false;
             this.updateTiming = updateTiming;
         }
-        void Update()
+        private void Update()
         {
             if(updateTiming != UpdateTiming.Update){ return; }
             GetPacketQueueInfo();
         }
-        void FixedUpdate()
+        private void FixedUpdate()
         {
             if(updateTiming != UpdateTiming.FixedUpdate){ return; }
             GetPacketQueueInfo();
         }
-        void LateUpdate()
+        private void LateUpdate()
         {
             if(updateTiming != UpdateTiming.LateUpdate){ return; }
             GetPacketQueueInfo();
         }
-        void GetPacketQueueInfo(){
+        private void GetPacketQueueInfo(){
             Result result = p2pInfo.Instance.GetPacketQueueInfo(out PacketQueueInformation packetQueueInformation);
             if(result == Result.Success){
-                Debug.Log($"PacketQueueInfo(Incoming): IncomingPacketQueueMaxSizeBytes: {packetQueueInformation.IncomingPacketQueueMaxSizeBytes} / IncomingPacketQueueCurrentSizeBytes: {packetQueueInformation.IncomingPacketQueueCurrentSizeBytes} / IncomingPacketQueueCurrentPacketCount: {packetQueueInformation.IncomingPacketQueueCurrentPacketCount}");
-                Debug.Log($"PacketQueueInfo(Outgoing): OutgoingPacketQueueMaxSizeBytes: {packetQueueInformation.OutgoingPacketQueueMaxSizeBytes} / OutgoingPacketQueueCurrentSizeBytes: {packetQueueInformation.OutgoingPacketQueueCurrentSizeBytes} / OutgoingPacketQueueCurrentPacketCount: {packetQueueInformation.OutgoingPacketQueueCurrentPacketCount}");
+                //Incoming Packets
+                if(packetQueueInformation.IncomingPacketQueueCurrentPacketCount != 0 || !incomingIsZero)
+                {
+                    incomingIsZero = packetQueueInformation.IncomingPacketQueueCurrentPacketCount == 0;
+                    Debug.Log($"PacketQueueInfo(Incoming): IncomingPacketQueueMaxSizeBytes: {packetQueueInformation.IncomingPacketQueueMaxSizeBytes} / IncomingPacketQueueCurrentSizeBytes: {packetQueueInformation.IncomingPacketQueueCurrentSizeBytes} / IncomingPacketQueueCurrentPacketCount: {packetQueueInformation.IncomingPacketQueueCurrentPacketCount}");   
+                }
+                // Outgoing Packets
+                if(packetQueueInformation.OutgoingPacketQueueCurrentPacketCount != 0 || !outgoingIsZero)
+                {
+                    outgoingIsZero = packetQueueInformation.OutgoingPacketQueueCurrentPacketCount == 0;
+                    Debug.Log($"PacketQueueInfo(Outgoing): OutgoingPacketQueueMaxSizeBytes: {packetQueueInformation.OutgoingPacketQueueMaxSizeBytes} / OutgoingPacketQueueCurrentSizeBytes: {packetQueueInformation.OutgoingPacketQueueCurrentSizeBytes} / OutgoingPacketQueueCurrentPacketCount: {packetQueueInformation.OutgoingPacketQueueCurrentPacketCount}");
+                }
             }
         }
     }

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/PacketMonitor.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/PacketMonitor.cs
@@ -1,0 +1,61 @@
+using SynicSugar.P2P;
+using UnityEngine;
+
+namespace SynicSugar.Samples {
+    public class PacketMonitor : MonoBehaviour
+    {
+    #region Singleton Instance
+        public static PacketMonitor Instance { get; private set; }
+        private void Awake() 
+        {
+            if( Instance != null ) 
+            {
+                Destroy( this.gameObject );
+                return;
+            }
+            Instance = this;
+        }
+        private void OnDestroy() 
+        {
+            if( Instance == this )
+            {
+                Instance = null;
+            }
+        }
+    #endregion
+        public enum UpdateTiming
+        {
+            None,
+            Update,
+            FixedUpdate,
+            LateUpdate
+        }
+        public UpdateTiming updateTiming { get; private set; }  = UpdateTiming.None;
+        public void SetUpdateTiming(UpdateTiming updateTiming)
+        {
+            this.updateTiming = updateTiming;
+        }
+        void Update()
+        {
+            if(updateTiming != UpdateTiming.Update){ return; }
+            GetPacketQueueInfo();
+        }
+        void FixedUpdate()
+        {
+            if(updateTiming != UpdateTiming.FixedUpdate){ return; }
+            GetPacketQueueInfo();
+        }
+        void LateUpdate()
+        {
+            if(updateTiming != UpdateTiming.LateUpdate){ return; }
+            GetPacketQueueInfo();
+        }
+        void GetPacketQueueInfo(){
+            Result result = p2pInfo.Instance.GetPacketQueueInfo(out PacketQueueInformation packetQueueInformation);
+            if(result == Result.Success){
+                Debug.Log($"PacketQueueInfo(Incoming): IncomingPacketQueueMaxSizeBytes: {packetQueueInformation.IncomingPacketQueueMaxSizeBytes} / IncomingPacketQueueCurrentSizeBytes: {packetQueueInformation.IncomingPacketQueueCurrentSizeBytes} / IncomingPacketQueueCurrentPacketCount: {packetQueueInformation.IncomingPacketQueueCurrentPacketCount}");
+                Debug.Log($"PacketQueueInfo(Outgoing): OutgoingPacketQueueMaxSizeBytes: {packetQueueInformation.OutgoingPacketQueueMaxSizeBytes} / OutgoingPacketQueueCurrentSizeBytes: {packetQueueInformation.OutgoingPacketQueueCurrentSizeBytes} / OutgoingPacketQueueCurrentPacketCount: {packetQueueInformation.OutgoingPacketQueueCurrentPacketCount}");
+            }
+        }
+    }
+}

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/PacketMonitor.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/PacketMonitor.cs
@@ -31,11 +31,11 @@ namespace SynicSugar.Samples {
             LateUpdate
         }
         public UpdateTiming updateTiming { get; private set; } = UpdateTiming.None;
-        private bool incomingIsZero, outgoingIsZero ;
+        private ulong prevIncomingPacketSize, prevOutgoingPacketSize;
         public void SetUpdateTiming(UpdateTiming updateTiming)
         {
-            incomingIsZero = false;
-            outgoingIsZero = false;
+            prevIncomingPacketSize = ulong.MaxValue;
+            prevOutgoingPacketSize = ulong.MaxValue;
             this.updateTiming = updateTiming;
         }
         private void Update()
@@ -57,16 +57,16 @@ namespace SynicSugar.Samples {
             Result result = p2pInfo.Instance.GetPacketQueueInfo(out PacketQueueInformation packetQueueInformation);
             if(result == Result.Success){
                 //Incoming Packets
-                if(packetQueueInformation.IncomingPacketQueueCurrentPacketCount != 0 || !incomingIsZero)
+                if(packetQueueInformation.IncomingPacketQueueCurrentPacketCount != prevIncomingPacketSize)
                 {
-                    incomingIsZero = packetQueueInformation.IncomingPacketQueueCurrentPacketCount == 0;
-                    Debug.Log($"PacketQueueInfo(Incoming): IncomingPacketQueueMaxSizeBytes: {packetQueueInformation.IncomingPacketQueueMaxSizeBytes} / IncomingPacketQueueCurrentSizeBytes: {packetQueueInformation.IncomingPacketQueueCurrentSizeBytes} / IncomingPacketQueueCurrentPacketCount: {packetQueueInformation.IncomingPacketQueueCurrentPacketCount}");   
+                    prevIncomingPacketSize = packetQueueInformation.IncomingPacketQueueCurrentPacketCount;
+                    Debug.Log($"PacketQueueInfo(Incoming): IncomingPacketQueueCurrentSizeBytes: {packetQueueInformation.IncomingPacketQueueCurrentSizeBytes} / IncomingPacketQueueCurrentPacketCount: {packetQueueInformation.IncomingPacketQueueCurrentPacketCount} / IncomingPacketQueueMaxSizeBytes: {packetQueueInformation.IncomingPacketQueueMaxSizeBytes}");   
                 }
                 // Outgoing Packets
-                if(packetQueueInformation.OutgoingPacketQueueCurrentPacketCount != 0 || !outgoingIsZero)
+                if(packetQueueInformation.OutgoingPacketQueueCurrentPacketCount != prevOutgoingPacketSize)
                 {
-                    outgoingIsZero = packetQueueInformation.OutgoingPacketQueueCurrentPacketCount == 0;
-                    Debug.Log($"PacketQueueInfo(Outgoing): OutgoingPacketQueueMaxSizeBytes: {packetQueueInformation.OutgoingPacketQueueMaxSizeBytes} / OutgoingPacketQueueCurrentSizeBytes: {packetQueueInformation.OutgoingPacketQueueCurrentSizeBytes} / OutgoingPacketQueueCurrentPacketCount: {packetQueueInformation.OutgoingPacketQueueCurrentPacketCount}");
+                    prevOutgoingPacketSize = packetQueueInformation.OutgoingPacketQueueCurrentPacketCount;
+                    Debug.Log($"PacketQueueInfo(Outgoing): OutgoingPacketQueueCurrentSizeBytes: {packetQueueInformation.OutgoingPacketQueueCurrentSizeBytes} / OutgoingPacketQueueCurrentPacketCount: {packetQueueInformation.OutgoingPacketQueueCurrentPacketCount} / OutgoingPacketQueueMaxSizeBytes: {packetQueueInformation.OutgoingPacketQueueMaxSizeBytes}");
                 }
             }
         }

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/PacketMonitor.cs.meta
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/1_Debug/PacketMonitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dd84cac8b27549bba33c905a1653dc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/Chat.unity
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/Chat.unity
@@ -638,8 +638,8 @@ PrefabInstance:
       value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1127570235843273856, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
-      propertyPath: _basicInfoPacketCompressionLevel
-      value: 1
+      propertyPath: p2pSetupTimeoutSec
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 1127570235843273856, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
       propertyPath: customSaveLobbyID.m_PersistentCalls.m_Calls.Array.size
@@ -710,6 +710,14 @@ PrefabInstance:
       value: NetworkManager
       objectReference: {fileID: 0}
     - target: {fileID: 2114254298220440419, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
+      propertyPath: RPCBatchSize
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2114254298220440419, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
+      propertyPath: relayControl
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2114254298220440419, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
       propertyPath: InitialConnection
       value: 2
       objectReference: {fileID: 0}
@@ -722,20 +730,16 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2114254298220440419, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
-      propertyPath: UseDisconnectedEarlyNotify
-      value: 1
+      propertyPath: LargePacketBatchSize
+      value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 4569237702368255570, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
-      propertyPath: _vcMode
+    - target: {fileID: 2114254298220440419, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
+      propertyPath: UseDisconnectedEarlyNotify
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4569237702368255570, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
       propertyPath: UseOpenVC
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569237702368255570, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
-      propertyPath: _voiceChatMode
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1686,7 +1690,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1839880479}
   m_Direction: 2
   m_Value: 0.9999997
-  m_Size: 0.66666675
+  m_Size: 0.6666666
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -3419,6 +3423,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6132300884961527158, guid: 9561edae41291f44e83554c3b8d20aba, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6132300884961527158, guid: 9561edae41291f44e83554c3b8d20aba, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
@@ -3496,7 +3504,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6132300885885006420, guid: 9561edae41291f44e83554c3b8d20aba, type: 3}
       propertyPath: m_Value
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -3962,7 +3970,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -762, y: -60}
-  m_SizeDelta: {x: 250, y: 60}
+  m_SizeDelta: {x: 350, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2022834940
 MonoBehaviour:

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/Chat.unity
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/Chat.unity
@@ -638,6 +638,10 @@ PrefabInstance:
       value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1127570235843273856, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
+      propertyPath: _basicInfoPacketCompressionLevel
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1127570235843273856, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
       propertyPath: customSaveLobbyID.m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
@@ -712,6 +716,10 @@ PrefabInstance:
     - target: {fileID: 2114254298220440419, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
       propertyPath: getPacketFrequency
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2114254298220440419, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
+      propertyPath: AllowDelayedDelivery
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2114254298220440419, guid: e18422c96d27f49489abe8b774c3a6b9, type: 3}
       propertyPath: UseDisconnectedEarlyNotify
@@ -3411,10 +3419,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6132300884961527158, guid: 9561edae41291f44e83554c3b8d20aba, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 6132300884961527158, guid: 9561edae41291f44e83554c3b8d20aba, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
@@ -3492,7 +3496,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6132300885885006420, guid: 9561edae41291f44e83554c3b8d20aba, type: 3}
       propertyPath: m_Value
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatMatchMake.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatMatchMake.cs
@@ -34,7 +34,9 @@ namespace SynicSugar.Samples.Chat
         //In fact, you had better check id like this on the Title screen after user Login to EOS.
         private void Start()
         {   
-            PacketMonitor.Instance.SetUpdateTiming(PacketMonitor.UpdateTiming.Update);
+            #if SYNICSUGAR_PACKETINFO
+                PacketMonitor.Instance.SetUpdateTiming(PacketMonitor.UpdateTiming.Update);
+            #endif
             Debug.Log("ChatMatchmake");
             //Prep matchmaking
             // SetGUIEvents();

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatMatchMake.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatMatchMake.cs
@@ -33,7 +33,8 @@ namespace SynicSugar.Samples.Chat
         //Second,　check whether this player is a reconnector.
         //In fact, you had better check id like this on the Title screen after user Login to EOS.
         private void Start()
-        {
+        {   
+            PacketMonitor.Instance.SetUpdateTiming(PacketMonitor.UpdateTiming.Update);
             Debug.Log("ChatMatchmake");
             //Prep matchmaking
             // SetGUIEvents();

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
@@ -56,7 +56,9 @@ namespace SynicSugar.Samples.Chat
         }
         void Oestroy()
         {
-            PacketMonitor.Instance.SetUpdateTiming(PacketMonitor.UpdateTiming.None);
+            #if SYNICSUGAR_PACKETINFO
+                PacketMonitor.Instance.SetUpdateTiming(PacketMonitor.UpdateTiming.None);
+            #endif
         }
 #if SYNICSUGAR_FPSTEST
         private void Update()

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
@@ -54,13 +54,17 @@ namespace SynicSugar.Samples.Chat
                 RTCManager.Instance.ParticipantUpdatedNotifier.Register(t => OnStartSpeaking(t), t => OnStopSpeaking(t));
             }
         }
-    #if SYNICSUGAR_FPSTEST
+        void Oestroy()
+        {
+            PacketMonitor.Instance.SetUpdateTiming(PacketMonitor.UpdateTiming.None);
+        }
+#if SYNICSUGAR_FPSTEST
         private void Update()
         {
             float fps = 1f / Time.deltaTime;
             Debug.Log("--UPDATE-- fps:" + fps);
         }
-    #endif
+#endif
         public void SwitchPanelContent()
         {
             matchmakeCanvas.SetActive(false);

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
@@ -83,6 +83,7 @@ namespace SynicSugar.Samples.Chat
                 ChatPlayer player = ConnectHub.Instance.GetUserInstance<ChatPlayer>(id);
                 count += $"{player.Name}: {player.submitCount} {Environment.NewLine}";
             }
+            inputCount.text = count;
         }
         private void OnDisconect(UserId id)
         {

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
@@ -54,7 +54,7 @@ namespace SynicSugar.Samples.Chat
                 RTCManager.Instance.ParticipantUpdatedNotifier.Register(t => OnStartSpeaking(t), t => OnStopSpeaking(t));
             }
         }
-        void Oestroy()
+        void OnDestroy()
         {
             #if SYNICSUGAR_PACKETINFO
                 PacketMonitor.Instance.SetUpdateTiming(PacketMonitor.UpdateTiming.None);

--- a/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Samples~/GameSample/2_Chat/ChatSystemManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 using SynicSugar.P2P;
@@ -48,25 +49,19 @@ namespace SynicSugar.Samples.Chat
             ConnectHub.Instance.StartPacketReceiver(PacketReceiveTiming.FixedUpdate, 5);
             if(p2pInfo.Instance.AllUserIds.Count > 1)//VC setting for Online mode.
             { 
-                await RTCManager.Instance.StartVoiceSending();
+                RTCManager.Instance.StartVoiceSending();
                 // VC actions with No args
                 // RTCManager.Instance.ParticipantUpdatedNotifier.Register(() => OnStartSpeaking(), t => OnStopSpeaking());
                 RTCManager.Instance.ParticipantUpdatedNotifier.Register(t => OnStartSpeaking(t), t => OnStopSpeaking(t));
             }
         }
-        void OnDestroy()
-        {
-            #if SYNICSUGAR_PACKETINFO
-                PacketMonitor.Instance.SetUpdateTiming(PacketMonitor.UpdateTiming.None);
-            #endif
-        }
-#if SYNICSUGAR_FPSTEST
+    #if SYNICSUGAR_FPSTEST
         private void Update()
         {
             float fps = 1f / Time.deltaTime;
             Debug.Log("--UPDATE-- fps:" + fps);
         }
-#endif
+    #endif
         public void SwitchPanelContent()
         {
             matchmakeCanvas.SetActive(false);
@@ -82,13 +77,11 @@ namespace SynicSugar.Samples.Chat
         
         public void UpdateChatCount()
         {
-            if(p2pInfo.Instance.AllUserIds.Count > 1)
+            string count = string.Empty;
+            foreach(var id in p2pInfo.Instance.AllUserIds)
             {
-                inputCount.text = $"ChatCount: {ConnectHub.Instance.GetUserInstance<ChatPlayer>(p2pInfo.Instance.LocalUserId).submitCount} / {ConnectHub.Instance.GetUserInstance<ChatPlayer>(p2pInfo.Instance.CurrentRemoteUserIds[0]).submitCount}";
-            }
-            else
-            {
-                inputCount.text = $"ChatCount: {ConnectHub.Instance.GetUserInstance<ChatPlayer>(p2pInfo.Instance.LocalUserId).submitCount} / --";
+                ChatPlayer player = ConnectHub.Instance.GetUserInstance<ChatPlayer>(id);
+                count += $"{player.Name}: {player.submitCount} {Environment.NewLine}";
             }
         }
         private void OnDisconect(UserId id)

--- a/SynicSugar/Assets/SynicSugar/package.json
+++ b/SynicSugar/Assets/SynicSugar/package.json
@@ -2,7 +2,7 @@
 {
   "name": "net.skeyll.synicsugar",
   "displayName": "SynicSugar",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "unity": "2021.3",
   "description": "High-level Networking Library for Mobile and Small-party Games with Epic Online Services.",
   "keywords": ["Network", "Services"],

--- a/docs/content/SynicSugar.P2P/p2pInfo.md
+++ b/docs/content/SynicSugar.P2P/p2pInfo.md
@@ -66,6 +66,7 @@ If this is no longer needed, we call *[CancelCurrentMatchMake](../../SynicSugar.
 | [GetNATType](../p2pInfo/getnattype) | Get last-queried NAT-type |
 | [GetPing](../p2pInfo/getping) | Get a ping with a peer from cache |
 | [RefreshPing](../p2pInfo/refreshping) | Refresh ping with other all peers |
+| [GetPacketQueueInfo](../p2pInfo/getpacketqueueinfo) | Get the packet queue info |
 
 
 

--- a/docs/content/SynicSugar.P2P/p2pInfo/GetPacketQueueInfo.md
+++ b/docs/content/SynicSugar.P2P/p2pInfo/GetPacketQueueInfo.md
@@ -1,0 +1,43 @@
++++
+title = "GetPacketQueueInfo"
+weight = 9
++++
+## GetPacketQueueInfo
+<small>*Namespace: SynicSugar.P2P* <br>
+*Class: p2pInfo* </small>
+
+public Result GetPacketQueueInfo(out PacketQueueInformation packetQueueInformation)
+
+
+### Description
+Get the information related to the current state of the packet queues. 
+
+
+```cs
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using SynicSugar;
+using SynicSugar.P2P;
+
+public class p2pSample : MonoBehaviour {
+    public void GetPacketQueueInfo(){
+        Result result = GetPacketQueueInfo(out PacketQueueInformation packetQueueInformation);
+
+        if(result == Result.Success)
+        {
+            //Incoming Packets
+            if(packetQueueInformation.IncomingPacketQueueCurrentPacketCount != prevIncomingPacketSize)
+            {
+                prevIncomingPacketSize = packetQueueInformation.IncomingPacketQueueCurrentPacketCount;
+                Debug.Log($"PacketQueueInfo(Incoming): IncomingPacketQueueCurrentSizeBytes: {packetQueueInformation.IncomingPacketQueueCurrentSizeBytes} / IncomingPacketQueueCurrentPacketCount: {packetQueueInformation.IncomingPacketQueueCurrentPacketCount} / IncomingPacketQueueMaxSizeBytes: {packetQueueInformation.IncomingPacketQueueMaxSizeBytes}");   
+            }
+            // Outgoing Packets
+            if(packetQueueInformation.OutgoingPacketQueueCurrentPacketCount != prevOutgoingPacketSize)
+            {
+                prevOutgoingPacketSize = packetQueueInformation.OutgoingPacketQueueCurrentPacketCount;
+                Debug.Log($"PacketQueueInfo(Outgoing): OutgoingPacketQueueCurrentSizeBytes: {packetQueueInformation.OutgoingPacketQueueCurrentSizeBytes} / OutgoingPacketQueueCurrentPacketCount: {packetQueueInformation.OutgoingPacketQueueCurrentPacketCount} / OutgoingPacketQueueMaxSizeBytes: {packetQueueInformation.OutgoingPacketQueueMaxSizeBytes}");
+            }
+        }
+    }
+}
+```


### PR DESCRIPTION
Fix
・(matchmaking) Fixed an issue where the Connection event was triggered before SendList during reconnection.
・(samples) Fixed the function to count chat messages to continue counting even after a user disconnects.
・ (rtc) Fixed a debug log in the volume adjustment method to handle cases where null is passed.
・ (core) Fixed a debug log to mask the UserId in SetLocalUserId.
	
Change
・ (matchmaking) Improved performance and readability of ConnectionSetupHandler.
・ (chore) Made NotifyEvents.Clear() public and implemented an alternative initialization process.
・(matchmaking) Explicitly initialized setup-related variables before establishing a connection.
・ (matchmaking) Changed behavior in EOSMatchmaking to return the internal Result directly instead of a Timeout on connection setup failure.
・(core) Modified logger format to clearly indicate messages from SynicSugar.

Add
・(p2p) Added GetPacketQueueInfo to p2pInfo.
・(sample) Added PacketMonitor function.